### PR TITLE
Fix replacement variable when fixDirLevel is false

### DIFF
--- a/tasks/data-uri.js
+++ b/tasks/data-uri.js
@@ -96,7 +96,7 @@ module.exports = function(grunt) {
             replacement = adjustDirectoryLevel(fixedUri, destDir, baseDir);
             grunt.log.ok('Adjust: '+ uri + ' -> ' + replacement);
           } else {
-            replacement = u;
+            replacement = uri;
             grunt.log.ok('Ignore: '+ uri);
           }
         }


### PR DESCRIPTION
Looks like this was just a refactoring bug; fixes #8.
