### PR TITLE
Add options.maxBytes, which allows us to avoid inlining images that are too large

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ grunt.initConfig({
         fixDirLevel: true,
         // img detecting base dir
         // baseDir: './'
+
+        // Do not inline any images larger
+        // than this size. 2048 is a size
+        // recommended by Google's mod_pagespeed.
+        maxBytes : 2048
+
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-data-uri",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Convert to data-uri from image path.",
   "keywords": [
     "gruntplugin",

--- a/tasks/data-uri.js
+++ b/tasks/data-uri.js
@@ -10,9 +10,9 @@ module.exports = function(grunt) {
 
   'use strict';
 
-  var fs      = require('fs'),
-      path    = require('path'),
-      datauri = require('datauri');
+  var fs       = require('fs'),
+      path     = require('path'),
+      datauri  = require('datauri');
 
   var RE_CSS_URLFUNC = /(?:url\(["']?)(.*?)(?:["']?\))/,
       util = grunt.util || grunt.utils, // for 0.4.0
@@ -86,10 +86,18 @@ module.exports = function(grunt) {
 
         // Assume file existing cause found from haystack
         if (haystack.indexOf(needle) !== -1) {
-          // Encoding to Data uri
-          replacement = datauri(needle);
 
-          grunt.log.ok('Encode: '+needle);
+          // check if file exceeds the max bytes
+          var fileSize = getFileSize(needle);
+          if (options.maxBytes && fileSize > options.maxBytes) {
+            // file is over the max size
+            grunt.log.ok('Skipping (size ' + fileSize + ' > ' + options.maxBytes +'): ' + uri);
+          } else {
+            // Encoding to Data uri
+            replacement = datauri(needle);
+
+            grunt.log.ok('Encode: '+needle);
+          }
         } else {
           if (options.fixDirLevel) {
             // Diff of directory level
@@ -110,6 +118,25 @@ module.exports = function(grunt) {
       grunt.log.ok('=> ' + outputTo);
     });
   });
+
+  /**
+   *
+   * @param fullPath
+   * @param options
+   * @return {boolean} the file size, or undefined if not found
+   */
+  function getFileSize(fullPath) {
+
+    if (!fs.existsSync(fullPath)) {
+      return false;
+    }
+
+    var stats = fs.statSync(fullPath);
+    if (!stats.isFile()) {
+      return false;
+    }
+    return stats.size;
+  }
 
   /**
    * @method adjustDirectoryLevel


### PR DESCRIPTION
I love this module, but a nice feature would be to limit inlining images that are too large.  The mod_pagespeed folks at Google, who supposedly know a lot about this, [recommend a maximum of 2048 bytes for HTML files and 3072 for CSS files](https://developers.google.com/speed/pagespeed/module/filter-image-optimize#ImageInlineMaxBytes).

So I modified the README to recommend setting `maxBytes` to 2048.  I figure it's safer to just assume the lowest good value everywhere, since it'd be tricky to figure out whether a file is HTML or CSS.
