### PR TITLE
Remove query and partial from urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "git://github.com/ahomu/grunt-data-uri.git"
   },
   "dependencies": {
-    "datauri": ">= 0.1"
+    "datauri": "~0.8.0"
   },
   "devDependencies": {
     "grunt": "~0.4.1"

--- a/tasks/data-uri.js
+++ b/tasks/data-uri.js
@@ -58,9 +58,6 @@ module.exports = function(grunt) {
         return;
       }
 
-      // Change base to src(css, html, js) existing dir
-      grunt.file.setBase(baseDir);
-
       // List uniq image URIs
       uris = util._.uniq(matches.map(function(m) {
         return m.match(RE_CSS_URLFUNC)[1];
@@ -81,7 +78,8 @@ module.exports = function(grunt) {
         fixedUri = (uri.indexOf('/') === 0 ? '.' + uri : uri).split('?')[0].split('#')[0];
 
         // Resolve image realpath
-        needle = path.resolve(fixedUri);
+        needle = path.join(baseDir, fixedUri);
+
 
         // Assume file existing cause found from haystack
         if (haystack.indexOf(needle) !== -1) {

--- a/tasks/data-uri.js
+++ b/tasks/data-uri.js
@@ -109,7 +109,8 @@ module.exports = function(grunt) {
           }
         }
 
-        content = content.replace(new RegExp(uri, 'g'), replacement);
+        var escapedUri = uri.replace(/\?/g, '\\$&');
+        content = content.replace(new RegExp(escapedUri, 'g'), replacement);
       });
 
       // Revert base to gruntjs executing current dir

--- a/tasks/data-uri.js
+++ b/tasks/data-uri.js
@@ -78,7 +78,7 @@ module.exports = function(grunt) {
         var src, replacement, needle, fixedUri;
 
         // fixed current dir when specified uri is like root
-        fixedUri = uri.indexOf('/') === 0 ? '.' + uri : uri;
+        fixedUri = (uri.indexOf('/') === 0 ? '.' + uri : uri).split('?')[0].split('#')[0];
 
         // Resolve image realpath
         needle = path.resolve(fixedUri);


### PR DESCRIPTION
There are projects, where css's URL contains query parameter (?) and/or partial (#).
For example:
```
../fonts/rw-widgets.svg?v=4.1.0#fontawesomeregular
../fonts/rw-widgets.eot?#iefix&v=4.1.0
```
This PR removes these parts, so grunt-data-uri will find those files.