### PR TITLE
Make version query to dependency more specific

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "git://github.com/ahomu/grunt-data-uri.git"
   },
   "dependencies": {
-    "datauri": ">= 0.1"
+    "datauri": "~0.1"
   },
   "devDependencies": {
     "grunt": "~0.4.1"


### PR DESCRIPTION
Hi, the current datauri package (1.0) breaks with your code. Marking the sem ver query more specific helps to prevent compatibility issues in the future.